### PR TITLE
refactor(bash): Allow insecure connection for private CM

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ jobs:
         SOURCE_DIR: '.'
         CHART_FOLDER: 'ecs-exporter'
         FORCE: 'True'
+        SKIP_SECURE: 'False'
         CHARTMUSEUM_URL: 'https://chartmuseum.url'
         CHARTMUSEUM_USER: '${{ secrets.CHARTMUSEUM_USER }}'
         CHARTMUSEUM_PASSWORD: ${{ secrets.CHARTMUSEUM_PASSWORD }}
@@ -36,6 +37,7 @@ The following settings must be passed as environment variables as shown in the e
 | `CHARTMUSEUM_URL` | Chartmuseum url | `env` | **Yes** |
 | `CHARTMUSEUM_USER` | Username for chartmuseum  | `secret` | **Yes** |
 | `CHARTMUSEUM_PASSWORD` | Password for chartmuseum | `secret` | **Yes** |
+| `SKIP_SECURE` | Allowing to push using insecure connection | `env` | No |
 | `FORCE` | Force chart upload (in case version exist in chartmuseum, upload will fail without `FORCE`). Defaults is `False` if not provided. | `env` | No |
 | `SOURCE_DIR` | The local directory you wish to upload. If your chart is in nested folder, `SOURCE_DIR` should be the path from root to the last folder before the one that stores the chart. For example, if your chart is in `./charts/app`, the `SOURCE_DIR` is `./charts/`. Defaults to the root of your repository (`.`) if not provided. | `env` | No |
 | `CHART_FOLDER` | Folder with charts in repo. This should be the name of the folder where the chart is in. For example, if your chart is in `./charts/app`, the `CHART_FOLDER` is `app` | `env` | **Yes** |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,6 +33,11 @@ elif [ "$FORCE" == "1" ] || [ "$FORCE" == "True" ] || [ "$FORCE" == "TRUE" ]; th
   FORCE="-f"
 fi
 
+if [ -z "$SKIP_SECURE" ] || [ "$SKIP_SECURE" == "False" ] || [ "$SKIP_SECURE" == "FALSE" ]; then
+  SKIP_SECURE=""
+elif [ "$SKIP_SECURE" == "1" ] || [ "$SKIP_SECURE" == "True" ] || [ "$SKIP_SECURE" == "TRUE" ]; then
+  SKIP_SECURE="--insecure"
+fi
 
 
 cd ${SOURCE_DIR}/${CHART_FOLDER}
@@ -49,4 +54,4 @@ helm dependency update .
 
 helm package .
 
-helm cm-push ${CHART_FOLDER}-* ${CHARTMUSEUM_URL} -u ${CHARTMUSEUM_USER} -p ${CHARTMUSEUM_PASSWORD} ${FORCE}
+helm cm-push ${CHART_FOLDER}-* ${CHARTMUSEUM_URL} -u ${CHARTMUSEUM_USER} -p ${CHARTMUSEUM_PASSWORD} ${FORCE} ${SKIP_SECURE}


### PR DESCRIPTION
We have private CM that uses custom certificate and its not recognized by Github ci

Therefore, I saw the need to have this option 